### PR TITLE
TC #1 Search Typeahead: Setup basic frontend UI

### DIFF
--- a/frontend/src/components/contacts-table-components/data-table.jsx
+++ b/frontend/src/components/contacts-table-components/data-table.jsx
@@ -15,6 +15,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import SearchContacts from "../search-contacts";
 
 
 import { DataTablePagination } from "./data-table-pagination";
@@ -61,6 +62,9 @@ const table = useReactTable({
       <div className="flex items-center justify-between py-4 mr-1">
         {/* Filter Component */}
         <DataTableFilter table={table} onFiltersChange={onFiltersChange} />
+
+        {/* Search Compononet */}
+        <SearchContacts />
         
         {/* View/Hide Columns Component */}
         <HideColumns table={table} />

--- a/frontend/src/components/search-contacts.jsx
+++ b/frontend/src/components/search-contacts.jsx
@@ -1,0 +1,21 @@
+import {useState, useEffect} from "react"
+
+const SearchContacts = () => {
+    const [searchTerm, setSearchTerm] = useState("");
+    const [result, setResult] = useState([]);
+
+
+    const handleChange = (e) => {
+        setSearchTerm(e.target.value)
+    }
+
+    return (
+    <div className="w-2/3 !h-10 flex justify-center">
+        <input type="text" placeholder="Search connections..." 
+        value={searchTerm} onChange={handleChange} className="outline-2 border-gray-200 w-full rounded-sm p-3 text-xl"/>
+      
+    </div>
+  )
+}
+
+export default SearchContacts;

--- a/frontend/src/components/search-contacts.jsx
+++ b/frontend/src/components/search-contacts.jsx
@@ -1,19 +1,50 @@
-import {useState, useEffect} from "react"
+import {useState, useEffect, useRef} from "react"
+import { Search } from "lucide-react";
 
 const SearchContacts = () => {
     const [searchTerm, setSearchTerm] = useState("");
-    const [result, setResult] = useState([]);
-
+    const [results, setResults] = useState([]);
+    const [showDropdown, setShowDropdown] = useState(false);
+    const typeaheadRef = useRef(null)
 
     const handleChange = (e) => {
         setSearchTerm(e.target.value)
     }
 
+
+    useEffect(() => {
+        const handleClickOutside = (e) => {
+            if (typeaheadRef.current && !typeaheadRef.current.contains(e.target)) {
+                setShowDropdown(false);
+            }
+        }
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, [typeaheadRef])
+
     return (
-    <div className="w-2/3 !h-10 flex justify-center">
+    <div className="relative w-2/3 !h-8 flex flex-col justify-center" ref={typeaheadRef}>
         <input type="text" placeholder="Search connections..." 
-        value={searchTerm} onChange={handleChange} className="outline-2 border-gray-200 w-full rounded-sm p-3 text-xl"/>
-      
+        value={searchTerm} onChange={handleChange} 
+        className="outline-1 border border-gray-200 w-full rounded-md p-2 text-xl focus:outline-none focus:ring-2 focus:ring-blue-600"
+        role="combobox" aria-autocomplete="list" aria-haspopup="listbox" aria-expanded={showDropdown}/>
+        <Search className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-700" />
+
+        {searchTerm && showDropdown && (
+            <ul className="absolute top-full left-0 w-full bg-white border border-gray-200 rounded-sm shadow-md mt-1 z-10 pl-10 pr-4">
+            {results.length > 0 ? (
+                results.map((result, index) => (
+                <li key={index} className="p-3 hover:bg-gray-100 cursor-pointer">
+                    {result}
+                </li>
+                ))
+            ) : (
+                <p className="p-3 text-gray-500">No results found.</p>
+            )}
+            </ul>
+        )}
     </div>
   )
 }


### PR DESCRIPTION
## Description
This PR..
- Implements custom frontend component for search in All Contacts Page
- Sets up basic UI and input box for users to type in

Later PRs...
- Create trie data structure for prefix matching
- Fetch data from supabase based on user input

## Milestones
- This works towards the first technical challenge 'users search typeahead' 
- User story of allowing users to search for connections

## Resources
- https://twitter.github.io/typeahead.js/examples/ (inspiration/example)

## Test Plan
<img width="2494" height="1417" alt="Screenshot 2025-07-10 at 2 19 53 PM" src="https://github.com/user-attachments/assets/04d83369-afc3-44ea-8a57-12aa6b78f67b" />
