### PR TITLE
TC #1 Search Typeahead (stretch): Add keyboard navigation and Individual Contact modal

### DIFF
--- a/Lynk/frontend/src/components/ViewContactCard.jsx
+++ b/Lynk/frontend/src/components/ViewContactCard.jsx
@@ -1,87 +1,167 @@
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
-import { Badge } from "@/components/ui/badge";
-import AvatarDemo from "./avatar-01";
-import { Linkedin, Twitter, Instagram, Mail, Phone, Building2, User, School, MapPin, Star, Tag, Briefcase, Globe, Heart } from "lucide-react";
-
-export default function ViewContactCard({ open, onOpenChange, contact }) {
-  if (!contact) return null;
-
-  const socials = contact.socials || {};
-  const colorMap = {
-    personal: "bg-purple-100 text-purple-800",
-    professional: "bg-green-100 text-green-800",
-    social: "bg-blue-100 text-blue-800",
-  };
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl p-8 rounded-2xl shadow-2xl">
-        <DialogHeader>
-          <div className="flex items-center gap-6 mb-4">
-            <AvatarDemo initials={contact.name ? contact.name[0] : "?"} url={contact.avatar_url} className="w-24 h-24 shadow-lg border-2 border-gray-200" />
-            <div>
-              <DialogTitle className="text-3xl font-bold flex items-center gap-2">
-                <User className="w-6 h-6 text-gray-500" />
-                {contact.name}
-              </DialogTitle>
-              <DialogDescription className="flex items-center gap-2 mt-1 text-lg">
-                {contact.role && <><Briefcase className="w-5 h-5 text-gray-400" />{contact.role}</>}
-                {contact.company && <><Building2 className="w-5 h-5 text-gray-400 ml-2" />{contact.company}</>}
-              </DialogDescription>
-              <div className="flex gap-2 mt-3">
-                {contact.relationship_type?.map((type, i) => (
-                  <Badge key={i} className={colorMap[type.toLowerCase()] + " text-base px-3 py-1"}>
-                    {type}
-                  </Badge>
-                ))}
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogDescription,
+    DialogFooter,
+  } from "@/components/ui/dialog";
+  import { Badge } from "@/components/ui/badge";
+  import AvatarDemo from "./avatar-01";
+  import {
+    Linkedin,
+    Twitter,
+    Instagram,
+    Mail,
+    Phone,
+    Building2,
+    User,
+    School,
+    MapPin,
+    Tag,
+    Briefcase,
+    Globe,
+    Heart,
+  } from "lucide-react";
+  
+  export default function ViewContactCard({ open, onOpenChange, contact }) {
+    if (!contact) return null;
+  
+    const socials = contact.socials || {};
+    const colorMap = {
+      personal: "bg-purple-100 text-purple-800",
+      professional: "bg-green-100 text-green-800",
+      social: "bg-blue-100 text-blue-800",
+    };
+  
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-7xl w-[90vw] p-10 md:p-12 rounded-3xl shadow-2xl bg-white border border-gray-100">
+          <DialogHeader>
+            <div className="flex flex-col md:flex-row gap-10">
+              <AvatarDemo
+                initials={contact.name ? contact.name[0] : "?"}
+                url={contact.avatar_url}
+                className="w-32 h-32 border-4 border-gray-200 shadow-lg"
+              />
+              <div className="flex-1 min-w-0">
+                <DialogTitle className="text-4xl font-extrabold flex items-center gap-3 break-words">
+                  <User className="w-7 h-7 text-gray-500" />
+                  {contact.name}
+                </DialogTitle>
+                <DialogDescription className="text-xl text-gray-700 mt-2 space-y-2">
+                  {contact.role && (
+                    <div className="flex items-center gap-2">
+                      <Briefcase className="w-5 h-5 text-gray-400" />
+                      {contact.role}
+                    </div>
+                  )}
+                  {contact.company && (
+                    <div className="flex items-center gap-2">
+                      <Building2 className="w-5 h-5 text-gray-400" />
+                      {contact.company}
+                    </div>
+                  )}
+                </DialogDescription>
+                <div className="flex flex-wrap gap-3 mt-4">
+                  {contact.relationship_type?.map((type, i) => (
+                    <Badge
+                      key={i}
+                      className={
+                        `${colorMap[type.toLowerCase()] || ""} text-sm px-4 py-1.5 font-semibold shadow-sm`
+                      }
+                    >
+                      {type}
+                    </Badge>
+                  ))}
+                </div>
               </div>
             </div>
+          </DialogHeader>
+  
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-x-16 gap-y-6 mt-10 text-lg">
+            {contact.email && (
+              <div className="flex items-center gap-3">
+                <Mail className="w-5 h-5 text-gray-500" />
+                <span className="break-all">{contact.email}</span>
+              </div>
+            )}
+            {contact.phone_number && (
+              <div className="flex items-center gap-3">
+                <Phone className="w-5 h-5 text-gray-500" />
+                {contact.phone_number}
+              </div>
+            )}
+            {contact.industry && (
+              <div className="flex items-center gap-3">
+                <Globe className="w-5 h-5 text-gray-500" />
+                {contact.industry}
+              </div>
+            )}
+            {contact.school && (
+              <div className="flex items-center gap-3">
+                <School className="w-5 h-5 text-gray-500" />
+                {contact.school}
+              </div>
+            )}
+            {contact.location && (
+              <div className="flex items-center gap-3">
+                <MapPin className="w-5 h-5 text-gray-500" />
+                {contact.location}
+              </div>
+            )}
+            {contact.interests?.length > 0 && (
+              <div className="flex items-center gap-3 flex-wrap">
+                <Heart className="w-5 h-5 text-pink-500" />
+                {contact.interests.join(", ")}
+              </div>
+            )}
+            {contact.tags?.length > 0 && (
+              <div className="flex items-center gap-3 flex-wrap">
+                <Tag className="w-5 h-5 text-gray-400" />
+                {contact.tags.join(", ")}
+              </div>
+            )}
           </div>
-        </DialogHeader>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4 mt-2 text-lg">
-          {contact.email && (
-            <div className="flex items-center gap-2"><Mail className="w-5 h-5 text-gray-500" />{contact.email}</div>
-          )}
-          {contact.phone_number && (
-            <div className="flex items-center gap-2"><Phone className="w-5 h-5 text-gray-500" />{contact.phone_number}</div>
-          )}
-          {contact.industry && (
-            <div className="flex items-center gap-2"><Globe className="w-5 h-5 text-gray-500" />{contact.industry}</div>
-          )}
-          {contact.school && (
-            <div className="flex items-center gap-2"><School className="w-5 h-5 text-gray-500" />{contact.school}</div>
-          )}
-          {contact.location && (
-            <div className="flex items-center gap-2"><MapPin className="w-5 h-5 text-gray-500" />{contact.location}</div>
-          )}
-          {contact.interests?.length > 0 && (
-            <div className="flex items-center gap-2 flex-wrap"><Heart className="w-5 h-5 text-pink-400" />{contact.interests.join(", ")}</div>
-          )}
-          {contact.tags?.length > 0 && (
-            <div className="flex items-center gap-2 flex-wrap"><Tag className="w-5 h-5 text-gray-400" />{contact.tags.join(", ")}</div>
-          )}
-        </div>
-        <div className="flex gap-6 mt-6 items-center">
-          {socials.linkedin && (
-            <a href={`https://${socials.linkedin}`} target="_blank" rel="noopener noreferrer" title="LinkedIn">
-              <Linkedin className="w-7 h-7 text-blue-700 hover:scale-110 transition-transform" />
-            </a>
-          )}
-          {socials.twitter && (
-            <a href={`https://twitter.com/${socials.twitter}`} target="_blank" rel="noopener noreferrer" title="Twitter">
-              <Twitter className="w-7 h-7 text-sky-500 hover:scale-110 transition-transform" />
-            </a>
-          )}
-          {socials.instagram && (
-            <a href={`https://instagram.com/${socials.instagram}`} target="_blank" rel="noopener noreferrer" title="Instagram">
-              <Instagram className="w-7 h-7 text-pink-500 hover:scale-110 transition-transform" />
-            </a>
-          )}
-        </div>
-        <DialogFooter>
-          {/* Footer actions go here */}
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
-} 
+  
+          <div className="flex gap-6 mt-10 justify-center md:justify-start">
+            {socials.linkedin && (
+              <a
+                href={`https://${socials.linkedin}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                title="LinkedIn"
+              >
+                <Linkedin className="w-8 h-8 text-blue-700 hover:scale-110 transition-transform" />
+              </a>
+            )}
+            {socials.twitter && (
+              <a
+                href={`https://twitter.com/${socials.twitter}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                title="Twitter"
+              >
+                <Twitter className="w-8 h-8 text-sky-500 hover:scale-110 transition-transform" />
+              </a>
+            )}
+            {socials.instagram && (
+              <a
+                href={`https://instagram.com/${socials.instagram}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                title="Instagram"
+              >
+                <Instagram className="w-8 h-8 text-pink-500 hover:scale-110 transition-transform" />
+              </a>
+            )}
+          </div>
+  
+          <DialogFooter className="mt-10 flex justify-end">
+            {/* Optional buttons can go here */}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+  

--- a/Lynk/frontend/src/components/ViewContactCard.jsx
+++ b/Lynk/frontend/src/components/ViewContactCard.jsx
@@ -1,0 +1,87 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import AvatarDemo from "./avatar-01";
+import { Linkedin, Twitter, Instagram, Mail, Phone, Building2, User, School, MapPin, Star, Tag, Briefcase, Globe, Heart } from "lucide-react";
+
+export default function ViewContactCard({ open, onOpenChange, contact }) {
+  if (!contact) return null;
+
+  const socials = contact.socials || {};
+  const colorMap = {
+    personal: "bg-purple-100 text-purple-800",
+    professional: "bg-green-100 text-green-800",
+    social: "bg-blue-100 text-blue-800",
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl p-8 rounded-2xl shadow-2xl">
+        <DialogHeader>
+          <div className="flex items-center gap-6 mb-4">
+            <AvatarDemo initials={contact.name ? contact.name[0] : "?"} url={contact.avatar_url} className="w-24 h-24 shadow-lg border-2 border-gray-200" />
+            <div>
+              <DialogTitle className="text-3xl font-bold flex items-center gap-2">
+                <User className="w-6 h-6 text-gray-500" />
+                {contact.name}
+              </DialogTitle>
+              <DialogDescription className="flex items-center gap-2 mt-1 text-lg">
+                {contact.role && <><Briefcase className="w-5 h-5 text-gray-400" />{contact.role}</>}
+                {contact.company && <><Building2 className="w-5 h-5 text-gray-400 ml-2" />{contact.company}</>}
+              </DialogDescription>
+              <div className="flex gap-2 mt-3">
+                {contact.relationship_type?.map((type, i) => (
+                  <Badge key={i} className={colorMap[type.toLowerCase()] + " text-base px-3 py-1"}>
+                    {type}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          </div>
+        </DialogHeader>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4 mt-2 text-lg">
+          {contact.email && (
+            <div className="flex items-center gap-2"><Mail className="w-5 h-5 text-gray-500" />{contact.email}</div>
+          )}
+          {contact.phone_number && (
+            <div className="flex items-center gap-2"><Phone className="w-5 h-5 text-gray-500" />{contact.phone_number}</div>
+          )}
+          {contact.industry && (
+            <div className="flex items-center gap-2"><Globe className="w-5 h-5 text-gray-500" />{contact.industry}</div>
+          )}
+          {contact.school && (
+            <div className="flex items-center gap-2"><School className="w-5 h-5 text-gray-500" />{contact.school}</div>
+          )}
+          {contact.location && (
+            <div className="flex items-center gap-2"><MapPin className="w-5 h-5 text-gray-500" />{contact.location}</div>
+          )}
+          {contact.interests?.length > 0 && (
+            <div className="flex items-center gap-2 flex-wrap"><Heart className="w-5 h-5 text-pink-400" />{contact.interests.join(", ")}</div>
+          )}
+          {contact.tags?.length > 0 && (
+            <div className="flex items-center gap-2 flex-wrap"><Tag className="w-5 h-5 text-gray-400" />{contact.tags.join(", ")}</div>
+          )}
+        </div>
+        <div className="flex gap-6 mt-6 items-center">
+          {socials.linkedin && (
+            <a href={`https://${socials.linkedin}`} target="_blank" rel="noopener noreferrer" title="LinkedIn">
+              <Linkedin className="w-7 h-7 text-blue-700 hover:scale-110 transition-transform" />
+            </a>
+          )}
+          {socials.twitter && (
+            <a href={`https://twitter.com/${socials.twitter}`} target="_blank" rel="noopener noreferrer" title="Twitter">
+              <Twitter className="w-7 h-7 text-sky-500 hover:scale-110 transition-transform" />
+            </a>
+          )}
+          {socials.instagram && (
+            <a href={`https://instagram.com/${socials.instagram}`} target="_blank" rel="noopener noreferrer" title="Instagram">
+              <Instagram className="w-7 h-7 text-pink-500 hover:scale-110 transition-transform" />
+            </a>
+          )}
+        </div>
+        <DialogFooter>
+          {/* Footer actions go here */}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+} 

--- a/Lynk/frontend/src/components/ViewContactCard.jsx
+++ b/Lynk/frontend/src/components/ViewContactCard.jsx
@@ -1,167 +1,164 @@
 import {
-    Dialog,
-    DialogContent,
-    DialogHeader,
-    DialogTitle,
-    DialogDescription,
-    DialogFooter,
-  } from "@/components/ui/dialog";
-  import { Badge } from "@/components/ui/badge";
-  import AvatarDemo from "./avatar-01";
-  import {
-    Linkedin,
-    Twitter,
-    Instagram,
-    Mail,
-    Phone,
-    Building2,
-    User,
-    School,
-    MapPin,
-    Tag,
-    Briefcase,
-    Globe,
-    Heart,
-  } from "lucide-react";
-  
-  export default function ViewContactCard({ open, onOpenChange, contact }) {
-    if (!contact) return null;
-  
-    const socials = contact.socials || {};
-    const colorMap = {
-      personal: "bg-purple-100 text-purple-800",
-      professional: "bg-green-100 text-green-800",
-      social: "bg-blue-100 text-blue-800",
-    };
-  
-    return (
-      <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="max-w-7xl w-[90vw] p-10 md:p-12 rounded-3xl shadow-2xl bg-white border border-gray-100">
-          <DialogHeader>
-            <div className="flex flex-col md:flex-row gap-10">
-              <AvatarDemo
-                initials={contact.name ? contact.name[0] : "?"}
-                url={contact.avatar_url}
-                className="w-32 h-32 border-4 border-gray-200 shadow-lg"
-              />
-              <div className="flex-1 min-w-0">
-                <DialogTitle className="text-4xl font-extrabold flex items-center gap-3 break-words">
-                  <User className="w-7 h-7 text-gray-500" />
-                  {contact.name}
-                </DialogTitle>
-                <DialogDescription className="text-xl text-gray-700 mt-2 space-y-2">
-                  {contact.role && (
-                    <div className="flex items-center gap-2">
-                      <Briefcase className="w-5 h-5 text-gray-400" />
-                      {contact.role}
-                    </div>
-                  )}
-                  {contact.company && (
-                    <div className="flex items-center gap-2">
-                      <Building2 className="w-5 h-5 text-gray-400" />
-                      {contact.company}
-                    </div>
-                  )}
-                </DialogDescription>
-                <div className="flex flex-wrap gap-3 mt-4">
-                  {contact.relationship_type?.map((type, i) => (
-                    <Badge
-                      key={i}
-                      className={
-                        `${colorMap[type.toLowerCase()] || ""} text-sm px-4 py-1.5 font-semibold shadow-sm`
-                      }
-                    >
-                      {type}
-                    </Badge>
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Badge } from "@/components/ui/badge"
+import AvatarDemo from "./avatar-01"
+import { Mail, Phone, Building2, School, MapPin, Tag, Briefcase, Globe, Heart, User, CalendarDays, Users, Star, MessageCircle, BookOpen, Info, Linkedin, Twitter, Instagram } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export default function ViewContactCard({ open, onOpenChange, contact }) {
+  if (!contact) return null
+
+  const colorMap = {
+    personal: "bg-purple-100 text-purple-800",
+    professional: "bg-green-100 text-green-800",
+    social: "bg-blue-100 text-blue-800",
+  }
+  const socials = contact.socials || {}
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="!max-w-screen-xl !w-[80vw] !max-h-[76vh] p-0 rounded-2xl shadow-2xl bg-white border-0 overflow-y-auto">
+        <div className="p-6 flex flex-col gap-6">
+          {/* Profile Header */}
+          <div className="flex flex-col md:flex-row gap-6 items-center md:items-start pb-3 border-b border-gray-100">
+            <AvatarDemo
+              initials={contact.name ? contact.name.split(" ").map((n) => n[0]).join("") : "?"}
+              url={contact.avatar_url}
+              className="w-30 h-30 border-4 border-gray-200 shadow-lg"
+            />
+            <div className="flex-1 min-w-0 flex flex-col gap-2">
+              <DialogTitle className="text-4xl font-bold flex items-center gap-2">
+                <User className="w-10 h-10 text-gray-400" />
+                {contact.name}
+              </DialogTitle>
+              {/* How can I help them button */}
+              <div className="mt-4 flex justify-left">
+                <Button
+                  className="bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 text-white px-6 py-2 rounded-xl text-base font-semibold shadow-md hover:from-blue-600 hover:to-pink-600 transition-all"
+                  type="button"
+                >
+                  How can I help {contact.name}?
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          {/* Contact Information */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="bg-gray-50 rounded-xl p-6 flex flex-col gap-4 shadow-sm">
+              <h3 className="text-xl font-semibold flex items-center gap-2 mb-1"><Info className="w-6 h-6 text-blue-500" />Contact Information</h3>
+              {contact.email && <div className="flex items-center gap-2 text-gray-800 text-lg"><Mail className="w-6 h-6 text-gray-400" />{contact.email}</div>}
+              {contact.phone_number && <div className="flex items-center gap-2 text-gray-800 text-lg"><Phone className="w-6 h-6 text-gray-400" />{contact.phone_number}</div>}
+            </div>
+
+            {/* Professional Information */}
+            <div className="bg-gray-50 rounded-xl p-6 flex flex-col gap-4 shadow-sm">
+              <h3 className="text-xl font-semibold flex items-center gap-2 mb-1"><Briefcase className="w-6 h-6 text-green-600" />Professional Information</h3>
+              {contact.company && <div className="flex items-center gap-2 text-gray-800 text-lg"><Building2 className="w-6 h-6 text-gray-400" />{contact.company}</div>}
+              {contact.role && <div className="flex items-center gap-2 text-gray-800 text-lg"><Briefcase className="w-6 h-6 text-gray-400" />{contact.role}</div>}
+              {contact.industry && <div className="flex items-center gap-2 text-gray-800 text-lg"><Globe className="w-6 h-6 text-gray-400" />{contact.industry}</div>}
+            </div>
+          </div>
+
+          {/* Background & Context */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="bg-gray-50 rounded-xl p-6 flex flex-col gap-4 shadow-sm">
+              <h3 className="text-xl font-semibold flex items-center gap-2 mb-1"><School className="w-6 h-6 text-indigo-600" />Background & Context</h3>
+              {contact.school && <div className="flex items-center gap-2 text-gray-800 text-lg"><School className="w-6 h-6 text-gray-400" />{contact.school}</div>}
+              {contact.where_met && <div className="flex items-center gap-2 text-gray-800 text-lg"><BookOpen className="w-6 h-6 text-gray-400" />Where met: {contact.where_met}</div>}
+              {contact.location && <div className="flex items-center gap-2 text-gray-800 text-lg"><MapPin className="w-6 h-6 text-gray-400" />{contact.location}</div>}
+            </div>
+            <div className="bg-gray-50 rounded-xl p-6 flex flex-col gap-4 shadow-sm">
+              <h3 className="text-xl font-semibold flex items-center gap-2 mb-1"><CalendarDays className="w-6 h-6 text-blue-600" />Last Contact & Notes</h3>
+              {contact.last_contact_at && <div className="flex items-center gap-2 text-gray-800 text-lg"><CalendarDays className="w-6 h-6 text-gray-400" />Last Contact: {new Date(contact.last_contact_at).toLocaleDateString()}</div>}
+              {contact.notes && <div className="flex items-center gap-2 text-gray-800 text-lg"><MessageCircle className="w-6 h-6 text-gray-400" />Notes: {contact.notes}</div>}
+            </div>
+          </div>
+
+          {/* Relationship & Categories */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="bg-gray-50 rounded-xl p-6 flex flex-col gap-4 shadow-sm">
+              <h3 className="text-xl font-semibold flex items-center gap-2 mb-1"><Star className="w-6 h-6 text-yellow-500" />Relationship & Categories</h3>
+              {typeof contact.interactions_count === 'number' && <div className="flex items-center gap-2 text-gray-800 text-lg"><Users className="w-6 h-6 text-gray-400" />Interactions: {contact.interactions_count}</div>}
+              {typeof contact.connection_score === 'number' && <div className="flex items-center gap-2 text-gray-800 text-lg"><Star className="w-6 h-6 text-yellow-400" />Score: {contact.connection_score}</div>}
+              {contact.tags?.length > 0 && (
+                <div className="flex flex-wrap gap-2 mt-2">
+                  {contact.tags.map((tag, i) => (
+                    <Badge key={i} className="bg-gray-200 text-gray-800 text-base px-4 py-2 font-semibold rounded-full">{tag}</Badge>
+                  ))}
+                </div>
+              )}
+              <div className="flex flex-wrap gap-2 mt-2">
+                {contact.relationship_type?.map((type, i) => (
+                  <Badge key={i} className={colorMap[type.toLowerCase()] + " text-base px-4 py-2 font-semibold"}>{type}</Badge>
+                ))}
+              </div>
+            </div>
+            {/* Interests Section */}
+            {contact.interests?.length > 0 && (
+              <div className="bg-gray-50 rounded-xl p-6 flex flex-col gap-4 shadow-sm">
+                <h3 className="text-xl font-semibold flex items-center gap-2 mb-1"><Heart className="w-6 h-6 text-pink-500" />Interests</h3>
+                <div className="flex flex-wrap gap-2">
+                  {contact.interests.map((interest, i) => (
+                    <Badge key={i} className="bg-pink-100 text-pink-800 px-4 py-2 text-base font-semibold">{interest}</Badge>
                   ))}
                 </div>
               </div>
+            )}
+          </div>
+
+          {/* Social Media Section */}
+          {(socials.linkedin || socials.twitter || socials.instagram) && (
+            <div className="rounded-2xl p-6 bg-gradient-to-r from-blue-50 to-purple-50 shadow-sm">
+              <h3 className="text-xl font-semibold flex items-center gap-2 mb-4 text-gray-900">
+                <Globe className="w-6 h-6 text-blue-500" /> Social Media
+              </h3>
+              <div className="flex gap-4">
+                {socials.linkedin && (
+                  <a
+                    href={`https://${socials.linkedin}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="w-14 h-14 rounded-xl flex items-center justify-center bg-[#0077b5] hover:bg-[#005983] transition-all shadow-lg"
+                  >
+                    <Linkedin className="w-7 h-7 text-white" />
+                  </a>
+                )}
+                {socials.twitter && (
+                  <a
+                    href={`https://twitter.com/${socials.twitter}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="w-14 h-14 rounded-xl flex items-center justify-center bg-[#1da1f2] hover:bg-[#0d8ddb] transition-all shadow-lg"
+                  >
+                    <Twitter className="w-7 h-7 text-white" />
+                  </a>
+                )}
+                {socials.instagram && (
+                  <a
+                    href={`https://instagram.com/${socials.instagram}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="w-14 h-14 rounded-xl flex items-center justify-center bg-gradient-to-tr from-pink-500 via-purple-500 to-yellow-500 hover:from-pink-600 hover:to-yellow-600 transition-all shadow-lg"
+                  >
+                    <Instagram className="w-7 h-7 text-white" />
+                  </a>
+                )}
+              </div>
             </div>
-          </DialogHeader>
-  
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-x-16 gap-y-6 mt-10 text-lg">
-            {contact.email && (
-              <div className="flex items-center gap-3">
-                <Mail className="w-5 h-5 text-gray-500" />
-                <span className="break-all">{contact.email}</span>
-              </div>
-            )}
-            {contact.phone_number && (
-              <div className="flex items-center gap-3">
-                <Phone className="w-5 h-5 text-gray-500" />
-                {contact.phone_number}
-              </div>
-            )}
-            {contact.industry && (
-              <div className="flex items-center gap-3">
-                <Globe className="w-5 h-5 text-gray-500" />
-                {contact.industry}
-              </div>
-            )}
-            {contact.school && (
-              <div className="flex items-center gap-3">
-                <School className="w-5 h-5 text-gray-500" />
-                {contact.school}
-              </div>
-            )}
-            {contact.location && (
-              <div className="flex items-center gap-3">
-                <MapPin className="w-5 h-5 text-gray-500" />
-                {contact.location}
-              </div>
-            )}
-            {contact.interests?.length > 0 && (
-              <div className="flex items-center gap-3 flex-wrap">
-                <Heart className="w-5 h-5 text-pink-500" />
-                {contact.interests.join(", ")}
-              </div>
-            )}
-            {contact.tags?.length > 0 && (
-              <div className="flex items-center gap-3 flex-wrap">
-                <Tag className="w-5 h-5 text-gray-400" />
-                {contact.tags.join(", ")}
-              </div>
-            )}
+          )}
+
+          {/* Meta Section */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 text-gray-500 text-base mt-4">
+            {contact.created_at && <div className="flex items-center gap-2"><CalendarDays className="w-5 h-5" />Created: {new Date(contact.created_at).toLocaleDateString()}</div>}
+            {contact.updated_at && <div className="flex items-center gap-2"><CalendarDays className="w-5 h-5" />Updated: {new Date(contact.updated_at).toLocaleDateString()}</div>}
           </div>
-  
-          <div className="flex gap-6 mt-10 justify-center md:justify-start">
-            {socials.linkedin && (
-              <a
-                href={`https://${socials.linkedin}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                title="LinkedIn"
-              >
-                <Linkedin className="w-8 h-8 text-blue-700 hover:scale-110 transition-transform" />
-              </a>
-            )}
-            {socials.twitter && (
-              <a
-                href={`https://twitter.com/${socials.twitter}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                title="Twitter"
-              >
-                <Twitter className="w-8 h-8 text-sky-500 hover:scale-110 transition-transform" />
-              </a>
-            )}
-            {socials.instagram && (
-              <a
-                href={`https://instagram.com/${socials.instagram}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                title="Instagram"
-              >
-                <Instagram className="w-8 h-8 text-pink-500 hover:scale-110 transition-transform" />
-              </a>
-            )}
-          </div>
-  
-          <DialogFooter className="mt-10 flex justify-end">
-            {/* Optional buttons can go here */}
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    );
-  }
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
   

--- a/Lynk/frontend/src/components/contacts-table-components/columns.jsx
+++ b/Lynk/frontend/src/components/contacts-table-components/columns.jsx
@@ -21,7 +21,7 @@ export function getInitials(fullName) {
     return `${firstInitial}${lastInitial}`;
   }
 
-export const columns =  (onDeleteContact, onUpdateContact) => [
+export const columns = (onDeleteContact, onUpdateContact, onViewContact) => [
   {
     id: "select",
     header: ({ table }) => (
@@ -64,9 +64,17 @@ export const columns =  (onDeleteContact, onUpdateContact) => [
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Name" />
     ),
-    cell: ({row}) => {
-      const name = row.getValue("name")
-      return <div className="text-left font-medium text-xl">{name}</div>
+    cell: ({ row }) => {
+      const name = row.getValue("name");
+      const contact = row.original;
+      return (
+        <div
+          className="text-center text-xl font-medium cursor-pointer hover:underline focus:outline-none"
+          onClick={() => onViewContact(contact)}
+        >
+          {name}
+        </div>
+      );
     },
     id: "name"
   },

--- a/Lynk/frontend/src/components/contacts-table-components/contacts-table.jsx
+++ b/Lynk/frontend/src/components/contacts-table-components/contacts-table.jsx
@@ -4,11 +4,14 @@ import { UserAuth } from "../../context/AuthContext";
 import { columns } from "./columns";
 import DataTable from "./data-table";
 import { toast } from "sonner";
+import ViewContactCard from "../ViewContactCard";
 
 const ContactsTable = () => {
   const { session } = UserAuth();
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [selectedContact, setSelectedContact] = useState(null);
+  const [modalOpen, setModalOpen] = useState(false);
 
   const handleContactUpdated = (updated) => {
     setData((prev) =>
@@ -44,12 +47,22 @@ const ContactsTable = () => {
     }
   }
 
+  const handleViewContact = (contact) => {
+    setSelectedContact(contact);
+    setModalOpen(true);
+  };
+
   return (
     <div className="mx-auto my-10">
       <DataTable 
-        columns={columns(onDeleteContact, handleContactUpdated)} 
+        columns={columns(onDeleteContact, handleContactUpdated, handleViewContact)} 
         data={data}
         loading={loading}
+      />
+      <ViewContactCard
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        contact={selectedContact}
       />
     </div>
   );

--- a/Lynk/frontend/src/components/contacts-table-components/row-actions.jsx
+++ b/Lynk/frontend/src/components/contacts-table-components/row-actions.jsx
@@ -11,12 +11,14 @@ import { DeleteConfirmationDialog } from "@/components/delete-confirmation-dialo
 import { SheetTrigger } from "@/components/ui/sheet"
 import { EditContact } from "../edit-contact-sheet"
 import { useState } from "react"
+import ViewContactCard from "../ViewContactCard";
 
 export const RowActions = ({ contact, onDeleteContact, onUpdateContact }) => {
   const [openEditSheet, setOpenEditSheet] = useState(false)
+  const [openViewModal, setOpenViewModal] = useState(false)
 
     return (
-      
+      <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" className="h-9 w-9 p-0">
@@ -27,7 +29,7 @@ export const RowActions = ({ contact, onDeleteContact, onUpdateContact }) => {
         <DropdownMenuContent align="end" className="w-48">
 
           {/* Viewing a Contact */}
-          <DropdownMenuItem className="flex items-center gap-3 text-lg py-3 cursor-pointer">
+          <DropdownMenuItem className="flex items-center gap-3 text-lg py-3 cursor-pointer" onClick={() => setOpenViewModal(true)}>
             <Eye className="h-5 w-5" />
             View Contact
           </DropdownMenuItem>
@@ -59,6 +61,8 @@ export const RowActions = ({ contact, onDeleteContact, onUpdateContact }) => {
           </DeleteConfirmationDialog>
         </DropdownMenuContent>
       </DropdownMenu>
+      <ViewContactCard open={openViewModal} onOpenChange={setOpenViewModal} contact={contact} />
+      </>
     )
   }
   

--- a/Lynk/frontend/src/components/search-contacts.jsx
+++ b/Lynk/frontend/src/components/search-contacts.jsx
@@ -200,7 +200,9 @@ const SearchContacts = () => {
                 <li key={index} id={`typeahead-option-${index}`}
                   ref={(el) => (optionRefs.current[index] = el)} role="option"
                   aria-selected={index === activeIndex} className={`py-2 px-6 cursor-pointer border-b border-gray-200 ${
-                    index === activeIndex ? "bg-blue-50" : "hover:bg-gray-100"}`}
+                    index === activeIndex 
+                      ? "bg-blue-50 border-l-4 border-l-blue-500" 
+                      : "hover:bg-gray-100"}`}
                   onMouseEnter={() => setActiveIndex(index)}
                   onClick={() => handleSelect(result)}
                 >

--- a/Lynk/frontend/src/components/search-contacts.jsx
+++ b/Lynk/frontend/src/components/search-contacts.jsx
@@ -1,149 +1,216 @@
-import {useState, useEffect, useRef} from "react"
+import { useState, useEffect, useRef } from "react";
 import { Search } from "lucide-react";
-import { Badge } from "@/components/ui/badge"; 
-import { Trie, fetchInitialContactsForSearch } from "../../../backend/index.js"
+import { Badge } from "@/components/ui/badge";
+import { Trie, fetchInitialContactsForSearch } from "../../../backend/index.js";
 import { getInitials } from "./contacts-table-components/columns.jsx";
-import AvatarDemo from "./avatar-01"
-import { useDebounce } from "../lib/useDebounce.js"
-import { UserAuth } from "../context/AuthContext.jsx"
+import AvatarDemo from "./avatar-01";
+import { useDebounce } from "../lib/useDebounce.js";
+import { UserAuth } from "../context/AuthContext.jsx";
 
 
-const SearchResult = ({ contact, index }) => {
+const SearchResult = ({ contact }) => {
   const colorMap = {
     personal: "bg-purple-100 text-purple-800 hover:bg-purple-200",
     professional: "bg-green-100 text-green-800 hover:bg-green-200",
-    social: "bg-blue-100 text-blue-800 hover:bg-blue-200"
+    social: "bg-blue-100 text-blue-800 hover:bg-blue-200",
   };
 
   return (
-    <li key={index} className="py-2 px-6 hover:bg-gray-100 cursor-pointer border-b border-gray-200">
-      <div className="flex items-center justify-between">
+    <div className="flex items-center justify-between">
+      <Search className="text-gray-700 mr-4 scale-80" />
 
-        {/* Left Section: Name and Role */}
-        <Search className=" transform  text-gray-700 mr-4 scale-80" />
-         <div className="flex-1 text-left">
-             
-            <div className="text-lg font-semibold">{contact.name} | 
-                <span className="text-sm text-gray-500 ml-1">{contact.role && contact.company ? `${contact.role} at ${contact.company}` : ''}</span>
-            </div>
-            
-        </div>
-
-        {/* Right Section: Relationship Type and Avatar */}
-        <div className="flex space-x-2">
-          {contact.relationship_type?.map((type, index) => (
-            <Badge 
-              key={index} 
-              variant="secondary"
-              className={`text-sm ${colorMap[type.toLowerCase()]}`}
-            >
-              {type}
-            </Badge>
-          ))}
-        </div>
-
-        <div className="flex items-center space-x-4 ml-2">
-          <AvatarDemo initials={getInitials(contact.name)} className="w-12 h-12 text-xl ml-2" />
+      <div className="flex-1 text-left">
+        <div className="text-lg font-semibold">
+          {contact.name}
+          {contact.role && contact.company && (
+            <>
+              {" "}
+              |{" "}
+              <span className="text-sm text-gray-500">
+                {`${contact.role} at ${contact.company}`}
+              </span>
+            </>
+          )}
         </div>
       </div>
-    </li>
+
+      <div className="flex space-x-2">
+        {contact.relationship_type?.map((type, index) => (
+          <Badge
+            key={index}
+            variant="secondary"
+            className={`text-sm ${colorMap[type.toLowerCase()]}`}
+          >
+            {type}
+          </Badge>
+        ))}
+      </div>
+
+      <div className="flex items-center space-x-4 ml-2">
+        <AvatarDemo initials={getInitials(contact.name)} url={contact.avatar_url} className="w-12 h-12 text-xl ml-2"/>
+      </div>
+    </div>
   );
 };
 
 
 const SearchContacts = () => {
-    const [searchTerm, setSearchTerm] = useState("");
-    const [results, setResults] = useState([]);
-    const [showDropdown, setShowDropdown] = useState(false);
-    const [trie, setTrie] = useState(new Trie());
-    const [isLoading, setIsLoading] = useState(false);
-    const [currentFirstChar, setCurrentFirstChar] = useState("");
-    const typeaheadRef = useRef(null)
-    const { session } = UserAuth();
-    const debouncedSearchTerm = useDebounce(searchTerm);
-    
+  const [searchTerm, setSearchTerm] = useState("");
+  const [results, setResults] = useState([]);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const [trie, setTrie] = useState(new Trie());
+  const [isLoading, setIsLoading] = useState(false);
+  const [currentFirstChar, setCurrentFirstChar] = useState("");
 
-    useEffect(() => {
-        const performSearch = async () => {
-            if (debouncedSearchTerm.length === 0) {
-                setResults([])
-                setShowDropdown(false)
-                setTrie(new Trie())
-                setCurrentFirstChar("")
-                return;
-            }
+  // keyboard-navigation state 
+  const [activeIndex, setActiveIndex] = useState(-1); // -1 = nothing highlighted
+  const optionRefs = useRef([]);
 
-            setIsLoading(true)
 
-            try {
-                const firstChar = debouncedSearchTerm[0].toLowerCase();
-                
-                
-                if (firstChar !== currentFirstChar) {
-                    const contacts = await fetchInitialContactsForSearch(session?.user?.id, firstChar)
-                    const newTrie = new Trie();
-                    newTrie.batchInsert(contacts)
-                    setTrie(newTrie)
-                    setCurrentFirstChar(firstChar)
-                    setResults(newTrie.findContactsWithPrefix(debouncedSearchTerm))
-                    setShowDropdown(true)
-                } else {
-                    
-                    setResults(trie.findContactsWithPrefix(debouncedSearchTerm))
-                    setShowDropdown(true)
-                }
-            } catch (error) {
-                console.error("Error performing search:", error)
-            } finally {
-                setIsLoading(false)
-            }
+  const typeaheadRef = useRef(null);
+  const { session } = UserAuth();
+  const debouncedSearchTerm = useDebounce(searchTerm);
+
+
+  useEffect(() => {
+    const performSearch = async () => {
+      if (debouncedSearchTerm.length === 0) {
+        setResults([])
+        setShowDropdown(false)
+        setTrie(new Trie())
+        setCurrentFirstChar("")
+        return;
+      }
+
+      setIsLoading(true)
+
+      try {
+        const firstChar = debouncedSearchTerm[0].toLowerCase();
+
+        if (firstChar !== currentFirstChar) {
+          const contacts = await fetchInitialContactsForSearch(session?.user?.id, firstChar);
+          const newTrie = new Trie();
+          newTrie.batchInsert(contacts)
+          setTrie(newTrie)
+          setCurrentFirstChar(firstChar)
+          setResults(newTrie.findContactsWithPrefix(debouncedSearchTerm))
+        } else {
+          setResults(trie.findContactsWithPrefix(debouncedSearchTerm))
         }
-        performSearch();
-    }, [debouncedSearchTerm, currentFirstChar])
 
-    const handleChange = async (e) => {
-        setSearchTerm(e.target.value)
+        setShowDropdown(true);
+      } catch (err) {
+        console.error("Error performing search:", err)
+      } finally {
+        setIsLoading(false);
+      }
     }
 
+    performSearch();
+  }, [debouncedSearchTerm, currentFirstChar]);
 
-    useEffect(() => {
-        const handleClickOutside = (e) => {
-            if (typeaheadRef.current && !typeaheadRef.current.contains(e.target)) {
-                setShowDropdown(false);
-            }
+  // reset highlight when list changes
+  useEffect(() => {
+    setActiveIndex(-1);
+    optionRefs.current = [];
+  }, [results]);
+
+  // keep highlighted item in view
+  useEffect(() => {
+    if (activeIndex >= 0 && optionRefs.current[activeIndex]) {
+      optionRefs.current[activeIndex].scrollIntoView({ block: "nearest" });
+    }
+  }, [activeIndex]);
+
+  // close dropdown on outside click 
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (typeaheadRef.current && !typeaheadRef.current.contains(e.target)) {
+        setShowDropdown(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleChange = (e) => setSearchTerm(e.target.value);
+
+  const handleSelect = (contact) => {
+    setSearchTerm(contact.name);
+    setShowDropdown(false);
+    // TO DO: Implement "view contact modal" upon clicking enter
+  };
+
+  return (
+    <div
+      ref={typeaheadRef}
+      className="relative w-2/4 !h-4 flex flex-col justify-center"
+    >
+      <input type="text" placeholder="Search connections..." 
+      value={searchTerm} onChange={handleChange}
+        onKeyDown={(e) => {
+          if (!showDropdown) return;
+          switch (e.key) {
+            case "ArrowDown":
+              e.preventDefault();
+              setActiveIndex((prev) =>
+                results.length ? (prev + 1) % results.length : -1
+              );
+              break;
+            case "ArrowUp":
+              e.preventDefault();
+              setActiveIndex((prev) =>
+                results.length ? prev <= 0 ? results.length - 1 : prev - 1 : -1);
+              break;
+            case "Enter":
+              if (activeIndex >= 0 && activeIndex < results.length) {
+                e.preventDefault();
+                handleSelect(results[activeIndex]);
+              }
+              break;
+            case "Escape":
+              setShowDropdown(false);
+              break;
+            default:
+              break;
+          }
+        }}
+        className="outline-1 border border-gray-200 w-full rounded-md p-2 text-xl focus:outline-none focus:ring-2 focus:ring-blue-600"
+        role="combobox" aria-autocomplete="list" aria-haspopup="listbox" aria-expanded={showDropdown}
+        aria-activedescendant={
+          activeIndex >= 0 ? `typeahead-option-${activeIndex}` : undefined
         }
-        document.addEventListener('mousedown', handleClickOutside);
-        return () => {
-            document.removeEventListener('mousedown', handleClickOutside);
-        };
-    }, [typeaheadRef])
+      />
+      <Search className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-700" />
 
-    return (
-        <div className="relative w-2/4 !h-4 flex flex-col justify-center" ref={typeaheadRef}>
-            <input type="text" placeholder="Search connections..." 
-            value={searchTerm} onChange={handleChange} 
-            className="outline-1 border border-gray-200 w-full rounded-md p-2 text-xl focus:outline-none focus:ring-2 focus:ring-blue-600"
-            role="combobox" aria-autocomplete="list" aria-haspopup="listbox" aria-expanded={showDropdown}/>
-            <Search className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-700" />
-
-            {searchTerm && showDropdown && (
-                <ul className="absolute top-full left-0 w-full bg-white border border-gray-200 rounded-sm shadow-md mt-4 z-10 ">
-                {isLoading ? (
-                            <div className="p-3 text-gray-500 flex items-center">
-                                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600 mr-2"></div>
-                                Searching...
-                            </div>
-                        ) : results.length > 0 ? (
-                            results.map((result, index) => (
-                                <SearchResult key={index} index={index} contact={result}/>
-                            ))
-                        ) : (
-                            <p className="p-3 text-gray-500">No results found.</p>
-                        )}
-                </ul>
-            )}
-        </div>
-    )
+      {searchTerm && showDropdown && (
+        <ul role="listbox"
+          className="absolute top-full left-0 w-full bg-white border border-gray-200 rounded-sm shadow-md mt-4 z-10 max-h-108 overflow-y-auto"
+        >
+          {isLoading ? (
+            <div className="p-3 text-gray-500 flex items-center">
+                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600 mr-2" />
+                    Searching...
+                </div>
+          ) : results.length ? (
+            results.map((result, index) => (
+              <li key={index} id={`typeahead-option-${index}`}
+                ref={(el) => (optionRefs.current[index] = el)} role="option"
+                aria-selected={index === activeIndex} className={`py-2 px-6 cursor-pointer border-b border-gray-200 ${
+                  index === activeIndex ? "bg-blue-50" : "hover:bg-gray-100"}`}
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => handleSelect(result)}
+              >
+                <SearchResult contact={result} />
+              </li>
+            ))
+          ) : (
+            <p className="p-3 text-gray-500">No results found.</p>
+          )}
+        </ul>
+      )}
+    </div>
+  )
 }
 
 export default SearchContacts;


### PR DESCRIPTION
## Description

**This PR...**
- Refactors the contact typeahead search and creates ViewContactCard modal 
- Implements a new, sectioned layout for the contact profile modal, grouping information into clear cards: Profile, Contact Info, Professional Info, Background & Context, Relationship & Categories, Interests, and Social Media.
- Adds a prominent, gradient "How can I help {name}?" button to the profile header.
- Ensures the typeahead search result dropdown supports keyboard navigation and opens the modal on click or Enter.
- Social media links are now shown as large, branded icon buttons in a gradient card, matching modern UI inspiration.

**Later PRs...**
- Add support for multi-select and editing of tags, interests, and relationship types directly from the modal.
- Implement Generative AI feature for recommendations on how to help the contact
- Implement complex filtering for the table

## Milestones
- This adds a seamless user experience to TC 1: Search Typeahead, and implements 1st stretch feature


## Resources
- https://ui.shadcn.com/docs/components/badge
- https://ui.shadcn.com/docs/components/dialog
- https://ui.shadcn.com/docs/components/button
- https://lucide.dev/icons/
- https://dribbble.com/tags/contact-management
- https://tailwindcss.com/docs/grid-template-columns


## Test Plan
<img width="1933" height="1460" alt="image" src="https://github.com/user-attachments/assets/b9f6346a-9c4c-42ed-a318-0b47c4f266e7" />
<img width="1953" height="1160" alt="image" src="https://github.com/user-attachments/assets/bb772f6e-2bc6-43e7-bcc8-0bf3e40ed4cf" />