### PR TITLE
Stretch features: Implement Quick Stats on Dashboard

### DIFF
--- a/Lynk/frontend/src/components/dashboard-components/NetworkAnalytics.jsx
+++ b/Lynk/frontend/src/components/dashboard-components/NetworkAnalytics.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import { BarChart3 } from "lucide-react";
+
+const NetworkAnalytics = () => (
+    <Card>
+        <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+                <BarChart3 className="h-5 w-5" />
+                Visualize Your Network
+            </CardTitle>
+        </CardHeader>
+        <CardContent>
+            <div className="h-80 flex items-center justify-center bg-muted/20 rounded-lg">
+                <p className="text-muted-foreground">Charts and visualizations coming soon...</p>
+            </div>
+        </CardContent>
+    </Card>
+);
+
+export default NetworkAnalytics; 

--- a/Lynk/frontend/src/components/dashboard-components/PinnedContacts.jsx
+++ b/Lynk/frontend/src/components/dashboard-components/PinnedContacts.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import { Star } from "lucide-react";
+
+const PinnedContacts = () => (
+    <div className="lg:col-span-1">
+        <Card className="h-full">
+            <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                    <Star className="h-5 w-5" />
+                    Pinned Contacts
+                </CardTitle>
+            </CardHeader>
+            <CardContent>
+                <div className="space-y-3">
+                    {[1, 2, 3].map((i) => (
+                        <div key={i} className="flex items-center gap-3 p-2 rounded-lg hover:bg-muted/50">
+                            <div className="w-8 h-8 bg-primary/20 rounded-full flex items-center justify-center">
+                                <span className="text-xs font-semibold">P{i}</span>
+                            </div>
+                            <div className="flex-1 min-w-0">
+                                <p className="text-sm font-medium truncate">Pinned User {i}</p>
+                                <p className="text-xs text-muted-foreground truncate">pinned@example.com</p>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </CardContent>
+        </Card>
+    </div>
+);
+
+export default PinnedContacts; 

--- a/Lynk/frontend/src/components/dashboard-components/QuickStats.jsx
+++ b/Lynk/frontend/src/components/dashboard-components/QuickStats.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import { TrendingUp } from "lucide-react";
+
+const QuickStats = () => (
+    <div className="lg:col-span-2">
+        <Card className="h-full">
+            <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                    <TrendingUp className="h-5 w-5" />
+                    Quick Stats
+                </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-8 flex-1 flex flex-col justify-center">
+                <div className="flex justify-between items-center">
+                    <span className="text-lg text-muted-foreground">Total Connections</span>
+                    <span className="text-4xl font-bold">127</span>
+                </div>
+                <div className="flex justify-between items-center">
+                    <span className="text-lg text-muted-foreground">New This Month</span>
+                    <span className="text-2xl font-semibold text-green-600">+12</span>
+                </div>
+                <div className="flex justify-between items-center">
+                    <span className="text-lg text-muted-foreground">Network Score</span>
+                    <span className="text-2xl font-semibold text-blue-600">8.5/10</span>
+                </div>
+            </CardContent>
+        </Card>
+    </div>
+);
+
+export default QuickStats; 

--- a/Lynk/frontend/src/components/dashboard-components/QuickStats.jsx
+++ b/Lynk/frontend/src/components/dashboard-components/QuickStats.jsx
@@ -1,32 +1,155 @@
 import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
-import { TrendingUp } from "lucide-react";
+import { Users, UserPlus, Factory, MessageCircle, Star, Users2 } from "lucide-react";
+import LoadingSpinner from "../ui/loading-spinner";
 
-const QuickStats = () => (
-    <div className="lg:col-span-2">
-        <Card className="h-full">
-            <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                    <TrendingUp className="h-5 w-5" />
-                    Quick Stats
-                </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-8 flex-1 flex flex-col justify-center">
-                <div className="flex justify-between items-center">
-                    <span className="text-lg text-muted-foreground">Total Connections</span>
-                    <span className="text-4xl font-bold">127</span>
-                </div>
-                <div className="flex justify-between items-center">
-                    <span className="text-lg text-muted-foreground">New This Month</span>
-                    <span className="text-2xl font-semibold text-green-600">+12</span>
-                </div>
-                <div className="flex justify-between items-center">
-                    <span className="text-lg text-muted-foreground">Network Score</span>
-                    <span className="text-2xl font-semibold text-blue-600">8.5/10</span>
-                </div>
-            </CardContent>
-        </Card>
+const RELATIONSHIP_TYPES = [
+    { type: "professional", color: "text-green-700" },
+    { type: "personal", color: "text-purple-700" },
+    { type: "social", color: "text-blue-700" },
+];
+
+function getStats(contacts) {
+    const now = new Date();
+    const thisMonth = now.getMonth();
+    const thisYear = now.getFullYear();
+
+    // 1. Total connections
+    const total = contacts.length;
+
+    // 2. New connections this month
+    const newThisMonth = contacts.filter(c => {
+        const added = c.added_at ? new Date(c.added_at) : null;
+        return added && added.getMonth() === thisMonth && added.getFullYear() === thisYear;
+    }).length;
+
+    // 3. Most common industry
+    const industryCounts = {};
+    contacts.forEach(c => {
+        if (c.industry) {
+            industryCounts[c.industry] = (industryCounts[c.industry] || 0) + 1;
+        }
+    });
+    let mostCommonIndustry = null;
+    let maxIndustryCount = 0;
+    Object.entries(industryCounts).forEach(([industry, count]) => {
+        if (count > maxIndustryCount) {
+            mostCommonIndustry = industry;
+            maxIndustryCount = count;
+        }
+    });
+
+    // 4. Average interactions per contact
+    const totalInteractions = contacts.reduce((sum, c) => sum + (c.interactions_count || 0), 0);
+    const avgInteractions = total > 0 ? (totalInteractions / total) : 0;
+
+    // 5. Most contacted contact
+    let mostContacted = null;
+    let maxInteractions = -1;
+    contacts.forEach(c => {
+        if ((c.interactions_count || 0) > maxInteractions) {
+            mostContacted = c;
+            maxInteractions = c.interactions_count || 0;
+        }
+    });
+
+    // 6. Relationship type counts
+    const relationshipTypeCounts = {
+        professional: 0,
+        personal: 0,
+        social: 0,
+    };
+    contacts.forEach(c => {
+        if (Array.isArray(c.relationship_type)) {
+            c.relationship_type.forEach(type => {
+                const t = type.toLowerCase();
+                if (relationshipTypeCounts[t] !== undefined) {
+                    relationshipTypeCounts[t]++;
+                }
+            });
+        }
+    });
+
+    return {
+        total,
+        newThisMonth,
+        mostCommonIndustry: mostCommonIndustry || "-",
+        avgInteractions: avgInteractions.toFixed(1),
+        mostContacted: mostContacted ? mostContacted.name : "-",
+        relationshipTypeCounts,
+    };
+}
+
+const statBox = (
+    icon, label, value, valueClass = ""
+) => (
+    <div className="flex flex-col items-center justify-center text-center w-full">
+        <div className="flex items-center justify-center gap-3 mb-1">
+            {icon}
+            <span className={`font-bold text-xl md:text-2xl ${valueClass}`}>{value}</span>
+        </div>
+        <div className="text-xs md:text-sm text-muted-foreground font-medium mb-0.5">{label}</div>
     </div>
 );
+
+const relationshipTypeStat = (counts) => (
+    <div className="flex flex-col items-center justify-center text-center w-full">
+        <div className="flex items-center justify-center gap-3 mb-1">
+            <Users2 className="h-8 w-8 text-primary" />
+            <span className="flex gap-2">
+                {RELATIONSHIP_TYPES.map(({ type, color }, idx) => (
+                    <span key={type} className={`font-semibold text-xs md:text-sm ${color}`}>{type}: {counts[type]}{idx < RELATIONSHIP_TYPES.length - 1 ? ',' : ''}</span>
+                ))}
+            </span>
+        </div>
+        <div className="text-xs md:text-sm text-muted-foreground font-medium mb-0.5">Connections by Type</div>
+    </div>
+);
+
+const QuickStats = ({ contacts, loading }) => {
+    const stats = getStats(contacts || []);
+    return (
+        <div className="lg:col-span-2">
+            <Card className="h-full">
+                <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                        <Users className="h-5 w-5" />
+                        <span className="text-lg md:text-xl">Quick Stats</span>
+                    </CardTitle>
+                </CardHeader>
+                <CardContent className="flex flex-col justify-center h-full">
+                    {loading ? (
+                        <div className="flex justify-center items-center h-48">
+                            <LoadingSpinner size={28} text="Loading stats..." />
+                        </div>
+                    ) : (
+                        <div className="grid grid-cols-2 grid-rows-3 gap-4 h-full w-full">
+                            {statBox(
+                                <Users className="h-8 w-8 text-primary" />, "Total Connections", stats.total
+                            )}
+                            {statBox(
+                                <UserPlus className="h-8 w-8 text-green-600" />, "New This Month", `+${stats.newThisMonth}`, "text-green-600"
+                            )}
+                            {statBox(
+                                <Factory className="h-8 w-8 text-blue-600" />, "Most Common Industry", <span className="text-base md:text-lg font-semibold">{stats.mostCommonIndustry}</span>
+                            )}
+                            {statBox(
+                                <MessageCircle className="h-8 w-8 text-yellow-600" />, "Avg. Interactions", <span className="text-base md:text-lg font-semibold">{stats.avgInteractions}</span>
+                            )}
+                            {relationshipTypeStat(stats.relationshipTypeCounts)}
+                            <div className="flex flex-col items-center justify-center text-center w-full">
+                                <div className="flex items-center justify-center gap-3 mb-1">
+                                    <Star className="h-8 w-8 text-pink-600" />
+                                    <span className="font-bold text-lg md:text-xl text-pink-600">{stats.mostContacted}</span>
+                                </div>
+                                <div className="text-xs md:text-sm text-muted-foreground font-medium mb-0.5">Most Contacted</div>
+                            </div>
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
+        </div>
+    );
+};
 
 export default QuickStats; 

--- a/Lynk/frontend/src/components/dashboard-components/TopConnectionsCarousel.jsx
+++ b/Lynk/frontend/src/components/dashboard-components/TopConnectionsCarousel.jsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import { Users } from "lucide-react";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "../ui/carousel";
+
+const TopConnectionsCarousel = ({ plugin }) => (
+    <div className="lg:col-span-1">
+        <Card className="h-full">
+            <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                    <Users className="h-5 w-5" />
+                    Top Connections
+                </CardTitle>
+            </CardHeader>
+            <CardContent className="flex-1">
+                <Carousel
+                    plugins={[plugin.current]}
+                    className="w-full h-full"
+                    onMouseEnter={plugin.current.stop}
+                    onMouseLeave={plugin.current.reset}
+                    opts={{
+                        align: "center",
+                        loop: true,
+                    }}
+                >
+                    <CarouselContent className="h-full">
+                        {[1, 2, 3, 4, 5].map((i) => (
+                            <CarouselItem key={i} className="basis-full h-full">
+                                <div className="p-4 h-full flex items-center">
+                                    <div className="bg-background border-2 rounded-lg shadow-lg hover:shadow-xl transition-shadow duration-300 p-6 w-full">
+                                        <div className="flex items-center gap-4 mb-4">
+                                            <div className="w-16 h-16 bg-primary/20 rounded-full flex items-center justify-center">
+                                                <span className="text-lg font-semibold">U{i}</span>
+                                            </div>
+                                            <div className="flex-1">
+                                                <p className="font-semibold text-lg">User {i}</p>
+                                                <p className="text-sm text-muted-foreground">Company {i}</p>
+                                            </div>
+                                        </div>
+                                        <div className="space-y-2">
+                                            <p className="text-sm text-muted-foreground">Last contact: 2 days ago</p>
+                                            <p className="text-sm text-muted-foreground">Connection strength: {8 + i}/10</p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </CarouselItem>
+                        ))}
+                    </CarouselContent>
+                    <CarouselPrevious />
+                    <CarouselNext />
+                </Carousel>
+            </CardContent>
+        </Card>
+    </div>
+);
+
+export default TopConnectionsCarousel; 

--- a/Lynk/frontend/src/pages/Dashboard.jsx
+++ b/Lynk/frontend/src/pages/Dashboard.jsx
@@ -1,16 +1,28 @@
-import React, { useRef } from "react";
+import React, { useRef, useEffect, useState } from "react";
 import { UserAuth } from "../context/AuthContext";
 import Autoplay from "embla-carousel-autoplay";
 import PinnedContacts from "../components/dashboard-components/PinnedContacts";
 import QuickStats from "../components/dashboard-components/QuickStats";
 import TopConnectionsCarousel from "../components/dashboard-components/TopConnectionsCarousel";
 import NetworkAnalytics from "../components/dashboard-components/NetworkAnalytics";
+import { fetchContacts } from "../../backend/index.js";
 
 const Dashboard = () => {
     const { session } = UserAuth();
     const plugin = useRef(
         Autoplay({ delay: 3000, stopOnInteraction: false })
     );
+    const [contacts, setContacts] = useState([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        if (!session?.user?.id) return;
+        setLoading(true);
+        fetchContacts(session.user.id).then(result => {
+            setContacts(result.success ? result.data : []);
+            setLoading(false);
+        });
+    }, [session?.user?.id]);
 
     return (
         <div className="container mx-auto p-6">
@@ -24,11 +36,11 @@ const Dashboard = () => {
             {/* Main Dashboard Grid */}
             <div className="grid grid-cols-1 lg:grid-cols-4 gap-6 mb-8">
                 {/* Top Left - Pinned Contacts */}
-                <PinnedContacts />
+                <PinnedContacts contacts={contacts} loading={loading} />
                 {/* Top Center - Quick Stats */}
-                <QuickStats />
+                <QuickStats contacts={contacts} loading={loading} />
                 {/* Top Right - Top Connections Carousel */}
-                <TopConnectionsCarousel plugin={plugin} />
+                <TopConnectionsCarousel contacts={contacts} loading={loading} plugin={plugin} />
             </div>
 
             {/* Network Analytics - Full Width */}

--- a/Lynk/frontend/src/pages/Dashboard.jsx
+++ b/Lynk/frontend/src/pages/Dashboard.jsx
@@ -5,7 +5,7 @@ import PinnedContacts from "../components/dashboard-components/PinnedContacts";
 import QuickStats from "../components/dashboard-components/QuickStats";
 import TopConnectionsCarousel from "../components/dashboard-components/TopConnectionsCarousel";
 import NetworkAnalytics from "../components/dashboard-components/NetworkAnalytics";
-import { fetchContacts } from "../../backend/index.js";
+import { fetchContacts } from "../../../backend/supabase/contacts.js";
 
 const Dashboard = () => {
     const { session } = UserAuth();

--- a/Lynk/frontend/src/pages/Dashboard.jsx
+++ b/Lynk/frontend/src/pages/Dashboard.jsx
@@ -1,20 +1,15 @@
 import React, { useRef } from "react";
 import { UserAuth } from "../context/AuthContext";
-import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
-import { Users, TrendingUp, Star, BarChart3 } from "lucide-react";
-import {
-  Carousel,
-  CarouselContent,
-  CarouselItem,
-  CarouselNext,
-  CarouselPrevious,
-} from "../components/ui/carousel";
 import Autoplay from "embla-carousel-autoplay";
+import PinnedContacts from "../components/dashboard-components/PinnedContacts";
+import QuickStats from "../components/dashboard-components/QuickStats";
+import TopConnectionsCarousel from "../components/dashboard-components/TopConnectionsCarousel";
+import NetworkAnalytics from "../components/dashboard-components/NetworkAnalytics";
 
 const Dashboard = () => {
     const { session } = UserAuth();
     const plugin = useRef(
-        Autoplay({ delay: 3000, stopOnInteraction: true })
+        Autoplay({ delay: 3000, stopOnInteraction: false })
     );
 
     return (
@@ -29,126 +24,17 @@ const Dashboard = () => {
             {/* Main Dashboard Grid */}
             <div className="grid grid-cols-1 lg:grid-cols-4 gap-6 mb-8">
                 {/* Top Left - Pinned Contacts */}
-                <div className="lg:col-span-1">
-                    <Card className="h-full">
-                        <CardHeader>
-                            <CardTitle className="flex items-center gap-2">
-                                <Star className="h-5 w-5" />
-                                Pinned Contacts
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent>
-                            <div className="space-y-3">
-                                {[1, 2, 3].map((i) => (
-                                    <div key={i} className="flex items-center gap-3 p-2 rounded-lg hover:bg-muted/50">
-                                        <div className="w-8 h-8 bg-primary/20 rounded-full flex items-center justify-center">
-                                            <span className="text-xs font-semibold">P{i}</span>
-                                        </div>
-                                        <div className="flex-1 min-w-0">
-                                            <p className="text-sm font-medium truncate">Pinned User {i}</p>
-                                            <p className="text-xs text-muted-foreground truncate">pinned@example.com</p>
-                                        </div>
-                                    </div>
-                                ))}
-                            </div>
-                        </CardContent>
-                    </Card>
-                </div>
-
+                <PinnedContacts />
                 {/* Top Center - Quick Stats */}
-                <div className="lg:col-span-2">
-                    <Card className="h-full">
-                        <CardHeader>
-                            <CardTitle className="flex items-center gap-2">
-                                <TrendingUp className="h-5 w-5" />
-                                Quick Stats
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent className="space-y-8 flex-1 flex flex-col justify-center">
-                            <div className="flex justify-between items-center">
-                                <span className="text-lg text-muted-foreground">Total Connections</span>
-                                <span className="text-4xl font-bold">127</span>
-                            </div>
-                            <div className="flex justify-between items-center">
-                                <span className="text-lg text-muted-foreground">New This Month</span>
-                                <span className="text-2xl font-semibold text-green-600">+12</span>
-                            </div>
-                            <div className="flex justify-between items-center">
-                                <span className="text-lg text-muted-foreground">Network Score</span>
-                                <span className="text-2xl font-semibold text-blue-600">8.5/10</span>
-                            </div>
-                        </CardContent>
-                    </Card>
-                </div>
-
+                <QuickStats />
                 {/* Top Right - Top Connections Carousel */}
-                <div className="lg:col-span-1">
-                    <Card className="h-full">
-                        <CardHeader>
-                            <CardTitle className="flex items-center gap-2">
-                                <Users className="h-5 w-5" />
-                                Top Connections
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent className="flex-1">
-                            <Carousel
-                                plugins={[plugin.current]}
-                                className="w-full h-full"
-                                onMouseEnter={plugin.current.stop}
-                                onMouseLeave={plugin.current.reset}
-                                opts={{
-                                    align: "center",
-                                    loop: true,
-                                }}
-                            >
-                                <CarouselContent className="h-full">
-                                    {[1, 2, 3, 4, 5].map((i) => (
-                                        <CarouselItem key={i} className="basis-full h-full">
-                                            <div className="p-4 h-full flex items-center">
-                                                <div className="bg-background border-2 rounded-lg shadow-lg hover:shadow-xl transition-shadow duration-300 p-6 w-full">
-                                                    <div className="flex items-center gap-4 mb-4">
-                                                        <div className="w-16 h-16 bg-primary/20 rounded-full flex items-center justify-center">
-                                                            <span className="text-lg font-semibold">U{i}</span>
-                                                        </div>
-                                                        <div className="flex-1">
-                                                            <p className="font-semibold text-lg">User {i}</p>
-                                                            <p className="text-sm text-muted-foreground">Company {i}</p>
-                                                        </div>
-                                                    </div>
-                                                    <div className="space-y-2">
-                                                        <p className="text-sm text-muted-foreground">Last contact: 2 days ago</p>
-                                                        <p className="text-sm text-muted-foreground">Connection strength: {8 + i}/10</p>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </CarouselItem>
-                                    ))}
-                                </CarouselContent>
-                                <CarouselPrevious />
-                                <CarouselNext />
-                            </Carousel>
-                        </CardContent>
-                    </Card>
-                </div>
+                <TopConnectionsCarousel plugin={plugin} />
             </div>
 
             {/* Network Analytics - Full Width */}
             <div className="mb-8">
-                <Card>
-                    <CardHeader>
-                        <CardTitle className="flex items-center gap-2">
-                            <BarChart3 className="h-5 w-5" />
-                            Visualize Your Network
-                        </CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                        <div className="h-80 flex items-center justify-center bg-muted/20 rounded-lg">
-                            <p className="text-muted-foreground">Charts and visualizations coming soon...</p>
-                        </div>
-                    </CardContent>
-                </Card>
+                <NetworkAnalytics />
             </div>
-
         </div>
     )
 }


### PR DESCRIPTION
## Description

**This PR...**
- Refactors the dashboard into modular, individual components: `QuickStats`, `PinnedContacts`, `TopConnectionsCarousel`, and `NetworkAnalytics` in `dashboard-components/`
- Fetches all user contacts data once in `Dashboard.jsx` and passes it as props to all dashboard components for efficiency and consistency
- Implements a fully dynamic, visually balanced QuickStats card with:
  - Total connections, new this month, most common industry, average interactions, most contacted, and connections by type (with icons and color)


**Later PRs...**
- Replace placeholder data in `PinnedContacts` and `TopConnectionsCarousel` with real user data and add interactivity (e.g., pin/unpin, modal)
- Implement real analytics and charts in `NetworkAnalytics`
- Add tests and edge case handling for empty/large datasets

## Milestones
- Implements the modular dashboard for the user stretch feature


## Resources
- [Shadcn/ui documentation](https://ui.shadcn.com/)
- [Tailwind CSS documentation](https://tailwindcss.com/)
- [Lucide Icons](https://lucide.dev/)
- [React best practices for dashboard data loading](https://kentcdodds.com/blog/application-state-management-with-react)
- Dashboard layout inspiration: [Dribbble Dashboards](https://dribbble.com/tags/dashboard)

## Test Plan
<img width="560" height="257" alt="image" src="https://github.com/user-attachments/assets/083adfde-cdd3-4d02-b547-dfacfa2ee69e" />