### PR TITLE
Stretch Features: Dashboard Top Connections Carousel

### DIFF
--- a/Lynk/frontend/src/components/dashboard-components/TopConnectionsCarousel.jsx
+++ b/Lynk/frontend/src/components/dashboard-components/TopConnectionsCarousel.jsx
@@ -8,56 +8,117 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from "../ui/carousel";
+import LoadingSpinner from "../ui/loading-spinner";
+import AvatarDemo from "../avatar-01";
 
-const TopConnectionsCarousel = ({ plugin }) => (
+function getScoreColor(score) {
+  if (score >= 70) return "bg-green-100 text-green-800";
+  if (score >= 30) return "bg-yellow-100 text-yellow-800";
+  return "bg-red-100 text-red-800";
+}
+
+const getInitials = (name) => {
+  if (!name) return "?";
+  const parts = name.split(" ");
+  if (parts.length === 1) return parts[0][0].toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+};
+
+const badgeColors = [
+  "bg-purple-100 text-purple-800",
+  "bg-green-100 text-green-800",
+  "bg-blue-100 text-blue-800",
+  "bg-orange-100 text-orange-800"
+];
+
+const TopConnectionsCarousel = ({ contacts, loading, plugin }) => {
+  // Sort by connection_score descending, take top 5
+  const topConnections = [...contacts]
+    .filter(c => typeof c.connection_score === 'number')
+    .sort((a, b) => b.connection_score - a.connection_score)
+    .slice(0, 5);
+
+  return (
     <div className="lg:col-span-1">
-        <Card className="h-full">
-            <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                    <Users className="h-5 w-5" />
-                    Top Connections
-                </CardTitle>
-            </CardHeader>
-            <CardContent className="flex-1">
-                <Carousel
-                    plugins={[plugin.current]}
-                    className="w-full h-full"
-                    onMouseEnter={plugin.current.stop}
-                    onMouseLeave={plugin.current.reset}
-                    opts={{
-                        align: "center",
-                        loop: true,
-                    }}
-                >
-                    <CarouselContent className="h-full">
-                        {[1, 2, 3, 4, 5].map((i) => (
-                            <CarouselItem key={i} className="basis-full h-full">
-                                <div className="p-4 h-full flex items-center">
-                                    <div className="bg-background border-2 rounded-lg shadow-lg hover:shadow-xl transition-shadow duration-300 p-6 w-full">
-                                        <div className="flex items-center gap-4 mb-4">
-                                            <div className="w-16 h-16 bg-primary/20 rounded-full flex items-center justify-center">
-                                                <span className="text-lg font-semibold">U{i}</span>
-                                            </div>
-                                            <div className="flex-1">
-                                                <p className="font-semibold text-lg">User {i}</p>
-                                                <p className="text-sm text-muted-foreground">Company {i}</p>
-                                            </div>
-                                        </div>
-                                        <div className="space-y-2">
-                                            <p className="text-sm text-muted-foreground">Last contact: 2 days ago</p>
-                                            <p className="text-sm text-muted-foreground">Connection strength: {8 + i}/10</p>
-                                        </div>
-                                    </div>
-                                </div>
-                            </CarouselItem>
-                        ))}
-                    </CarouselContent>
-                    <CarouselPrevious />
-                    <CarouselNext />
-                </Carousel>
-            </CardContent>
-        </Card>
+      <Card className="h-full">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Users className="h-5 w-5" />
+            Top Connections
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="flex-1">
+          {loading ? (
+            <div className="flex justify-center items-center h-48">
+              <LoadingSpinner size={32} text="Loading top connections..." />
+            </div>
+          ) : topConnections.length === 0 ? (
+            <div className="text-center text-muted-foreground py-6">No connections to show.</div>
+          ) : (
+            <Carousel
+              plugins={[plugin.current]}
+              className="w-full h-full"
+              onMouseEnter={plugin.current.stop}
+              onMouseLeave={plugin.current.reset}
+              opts={{
+                align: "center",
+                loop: true,
+              }}
+            >
+              <CarouselContent className="h-full">
+                {topConnections.map((connection, idx) => (
+                  <CarouselItem key={connection.id} className="basis-full h-full">
+                    <div className="flex justify-center items-center h-1/2">
+                      <Card className="relative w-full max-w-[250px] h-[300px] flex flex-col items-center shadow-lg border-2 hover:shadow-xl transition-all duration-200">
+                        {/* Rank badge top left */}
+                        <div className="absolute top-4 left-4">
+                          <span className="px-2 py-1 rounded text-lg font-semibold bg-gray-100 text-gray-700">#{idx + 1}</span>
+                        </div>
+                        {/* Score badge top right */}
+                        <div className="absolute top-4 right-4">
+                          <span className={`px-2 py-1 rounded text-lg font-semibold ${getScoreColor(connection.connection_score)}`}>{connection.connection_score}</span>
+                        </div>
+                        <CardHeader className="flex flex-row items-center justify-center gap-4 pt-10 pb-2 w-full">
+                          <AvatarDemo
+                            url={connection.avatar_url}
+                            initials={getInitials(connection.name)}
+                            className="w-24 h-24 text-3xl mb-1"
+                          />
+                          <div className="font-semibold text-xl text-black text-left w-auto mb-1">
+                            {connection.name}
+                          </div>
+                        </CardHeader>
+                        <CardContent className="flex flex-col items-center w-full px-4 pt-0">
+                          <div className="flex flex-wrap gap-1 justify-center mb-2 w-full">
+                            {connection.interests?.slice(0, 3).map((interest, idx) => (
+                              <span
+                                key={idx}
+                                className={`text-xs px-2 py-1 rounded ${badgeColors[idx % badgeColors.length]}`}
+                              >
+                                {interest}
+                              </span>
+                            ))}
+                          </div>
+                          <div className="text-sm text-muted-foreground w-full text-center mb-1">
+                            Last contact: {connection.last_contact_at ? new Date(connection.last_contact_at).toLocaleDateString() : 'N/A'}
+                          </div>
+                          <div className="text-sm text-muted-foreground w-full text-center">
+                            Interactions: {connection.interactions_count}
+                          </div>
+                        </CardContent>
+                      </Card>
+                    </div>
+                  </CarouselItem>
+                ))}
+              </CarouselContent>
+              <CarouselPrevious />
+              <CarouselNext />
+            </Carousel>
+          )}
+        </CardContent>
+      </Card>
     </div>
-);
+  );
+};
 
 export default TopConnectionsCarousel; 


### PR DESCRIPTION
## Description

**This PR...**
- Implements a connection scoring algorithm in Supabase for the `user_to_connections` table, with a trigger to keep `connection_score` up-to-date on insert/update
- Backfills all existing connection scores using the new formula
- Refactors the frontend to display the top 5 connections by `connection_score` in the dashboard carousel
- Updates the carousel UI to match the recommendation card style: shows avatar, full name, connection score badge (top right), rank badge (top left), interests, last contact, and interactions
- Uses the shared `AvatarDemo` component for consistent avatar rendering and improves card layout and responsiveness

**Later PRs...**
- Add modal/details view for top connections
- Allow pinning/unpinning directly from the carousel
- Add analytics and trends based on connection scores
- Add tests for connection scoring and carousel rendering

**Rationale**
The connection score algorithm provides a normalized (0–100) measure of relationship strength, factoring in interactions, recency, and relationship type. This enables a more meaningful and dynamic “Top Connections” experience for users, surfacing their most important contacts and encouraging engagement. The new UI matches the design of recommendations for a cohesive dashboard experience.
<img width="986" height="304" alt="image" src="https://github.com/user-attachments/assets/e53b4171-8c5d-431f-a7b7-60c35a1a6116" />


## Milestones

- Completes the core “Top Connections” feature for the dashboard
- Establishes a scalable, extensible foundation for future analytics and engagement features

## Resources

- [Supabase Triggers & Functions](https://supabase.com/docs/guides/database/triggers)
- [Postgres CASE and ARRAY functions](https://www.postgresql.org/docs/current/functions-array.html)
- [Shadcn/ui documentation](https://ui.shadcn.com/)
- [React Carousel Patterns](https://ui.shadcn.com/docs/components/carousel)
- [Lucide Icons](https://lucide.dev/)

## Test Plan

- Carousel displays top 5 connections by score, with correct avatars, names, badges, and interests
- Score and rank badges render in the correct positions, and the UI is responsive

<img width="295" height="324" alt="image" src="https://github.com/user-attachments/assets/4bb3173f-acd6-49a0-9632-b1b89d6cef2d" />