### PR TITLE
Stretch features: Light / Dark Mode

### DIFF
--- a/Lynk/frontend/src/App.jsx
+++ b/Lynk/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import AllContacts from './pages/AllContacts';
 // import TestPipeline from './pages/TestPipeline';
 import { Toaster } from "sonner";
 import AppLayout from './components/layout/AppLayout';
+import { ThemeProvider } from './components/theme-provider';
 
 export const router = createBrowserRouter([
   {
@@ -69,10 +70,10 @@ export const router = createBrowserRouter([
 
 function App() {
   return (
-    <>
+    <ThemeProvider defaultTheme="system" storageKey="lynk-ui-theme">
       <Toaster richColors position="bottom-center" />
       <Outlet />
-    </>
+    </ThemeProvider>
   )
 }
 

--- a/Lynk/frontend/src/components/RelationshipGuidanceSheet.jsx
+++ b/Lynk/frontend/src/components/RelationshipGuidanceSheet.jsx
@@ -293,7 +293,7 @@ export default function RelationshipGuidanceSheet({
                       Sources & Research
                     </h4>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                      {sources.slice(0, 6).map((source, index) => (
+                      {sources.slice(0, 10).map((source, index) => (
                         <a href={source.url} target="_blank" rel="noopener noreferrer" key={index}>
                           <HoverCard>
                           <HoverCardTrigger asChild>
@@ -342,9 +342,9 @@ export default function RelationshipGuidanceSheet({
                         </a>
                       ))}
                     </div>
-                    {sources.length > 6 && (
+                    {sources.length > 10 && (
                       <p className="text-xs text-gray-500 mt-2 text-center">
-                        Showing top 6 of {sources.length} sources
+                        Showing top 10 of {sources.length} sources
                       </p>
                     )}
                   </div>

--- a/Lynk/frontend/src/components/dashboard-components/TopConnectionsCarousel.jsx
+++ b/Lynk/frontend/src/components/dashboard-components/TopConnectionsCarousel.jsx
@@ -92,7 +92,7 @@ const TopConnectionsCarousel = ({ contacts, loading, plugin, onContactClick }) =
                             initials={getInitials(connection.name)}
                             className="w-24 h-24 text-3xl mb-1"
                           />
-                          <div className="font-semibold text-xl text-black text-left w-auto mb-1">
+                          <div className="font-semibold text-xl text-left w-auto mb-1">
                             {connection.name}
                           </div>
                         </CardHeader>

--- a/Lynk/frontend/src/components/layout/AppLayout.jsx
+++ b/Lynk/frontend/src/components/layout/AppLayout.jsx
@@ -4,7 +4,7 @@ import GlobalLoadingIndicator from './GlobalLoadingIndicator';
 const AppLayout = ({ children }) => {
   const currentYear = new Date().getFullYear();
   return (
-    <div className="min-h-screen bg-background flex flex-col">
+    <div className="min-h-screen bg-background flex flex-col w-full">
       <Navigation />
       <main className="flex-1">{children}</main>
       <GlobalLoadingIndicator />

--- a/Lynk/frontend/src/components/layout/Navigation.jsx
+++ b/Lynk/frontend/src/components/layout/Navigation.jsx
@@ -29,6 +29,7 @@ import {
 } from 'lucide-react';
 import lynkLogo from "../../lynk-logo.png";
 import { toast } from 'sonner';
+import { ModeToggle } from '../mode-toggle';
 
 const Navigation = () => {
   const { session, signOut, profile } = UserAuth();
@@ -137,7 +138,11 @@ const Navigation = () => {
              />
            ))}
          </div>
-        <div className="mt-auto pt-6 border-t">
+        <div className="mt-auto pt-6 border-t space-y-4">
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-muted-foreground">Theme</span>
+            <ModeToggle />
+          </div>
           <UserProfileDropdown />
         </div>
       </SheetContent>
@@ -178,6 +183,7 @@ const Navigation = () => {
 
           {/* User Profile and Mobile Menu */}
           <div className="flex items-center space-x-2">
+            <ModeToggle />
             <UserProfileDropdown />
             <MobileMenu />
           </div>

--- a/Lynk/frontend/src/components/mode-toggle.jsx
+++ b/Lynk/frontend/src/components/mode-toggle.jsx
@@ -1,0 +1,26 @@
+import { Moon, Sun } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { useTheme } from './theme-provider'
+
+export function ModeToggle() {
+  const { theme, setTheme } = useTheme()
+
+  const toggleTheme = () => {
+    const newTheme = theme === 'dark' ? 'light' : 'dark'
+    setTheme(newTheme)
+  }
+
+  return (
+    <Button 
+      variant="outline" 
+      size="icon" 
+      onClick={toggleTheme}
+      className="h-10 w-10 border-2 rounded-lg transition-all duration-200 hover:scale-105"
+    >
+      <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  )
+}

--- a/Lynk/frontend/src/components/theme-provider.jsx
+++ b/Lynk/frontend/src/components/theme-provider.jsx
@@ -1,0 +1,60 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+
+const initialState = {
+  theme: 'system',
+  setTheme: () => null,
+}
+
+const ThemeProviderContext = createContext(initialState)
+
+export function ThemeProvider({
+  children,
+  defaultTheme = 'system',
+  storageKey = 'lynk-ui-theme',
+  ...props
+}) {
+  const [theme, setTheme] = useState(
+    () => localStorage.getItem(storageKey) || defaultTheme
+  )
+
+  useEffect(() => {
+    const root = window.document.documentElement
+
+    root.classList.remove('light', 'dark')
+
+    if (theme === 'system') {
+      const systemTheme = window.matchMedia('(prefers-color-scheme: dark)')
+        .matches
+        ? 'dark'
+        : 'light'
+
+      root.classList.add(systemTheme)
+      return
+    }
+
+    root.classList.add(theme)
+  }, [theme])
+
+  const value = {
+    theme,
+    setTheme: (theme) => {
+      localStorage.setItem(storageKey, theme)
+      setTheme(theme)
+    },
+  }
+
+  return (
+    <ThemeProviderContext.Provider {...props} value={value}>
+      {children}
+    </ThemeProviderContext.Provider>
+  )
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeProviderContext)
+
+  if (context === undefined)
+    throw new Error('useTheme must be used within a ThemeProvider')
+
+  return context
+}

--- a/Lynk/frontend/src/index.css
+++ b/Lynk/frontend/src/index.css
@@ -30,8 +30,6 @@
   justify-content: center;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -72,9 +70,9 @@
 }
 
 #root {
-  width: 80%;
-  height: 95%;
-  margin: 1em auto;
+  width: 100%;
+  min-height: 100vh;
+  margin: 0;
 }
 
 a {
@@ -117,15 +115,7 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-}
+/* Removed media query that was overriding theme colors */
 
 @theme inline {
   --radius-sm: calc(var(--radius) - 4px);


### PR DESCRIPTION
## Description

- Implements light/dark mode toggle for the entire application using ShadCN UI patterns
- Creates theme provider component with localStorage persistence and system theme detection
- Adds bordered toggle button in navigation bar that switches between light and dark themes
- Fixes CSS configuration issues that were preventing theme switching
- Resolves app width constraint issue (was 80% width, now full viewport width)

## Milestones
- This enhances the core UI/UX experience across all features by providing user preference for theme
- Improves accessibility and user comfort with dark mode option
- Sets foundation for consistent theming across all future components and pages

## Resources
- Theme implementation pattern from ShadCN UI: https://ui.shadcn.com/docs/dark-mode/vite
- CSS variables approach for theme switching: https://ui.shadcn.com/docs/theming

## Test Plan
- Tested theme toggle functionality in navigation bar
- Verified theme persistence across browser sessions using localStorage
- Tested system theme detection on initial load
- Verified all existing components (dashboard, contacts, navigation) properly adapt to both themes
- Tested theme switching in mobile responsive view
- Confirmed theme toggle works in both desktop and mobile navigation menus

<img width="1919" height="798" alt="image" src="https://github.com/user-attachments/assets/0c930768-cd0c-4869-9c8f-e9976f8ddcf1" />